### PR TITLE
Consistent license statements for Creative Commons Attribution 4.0 International (CC-BY-4.0) license

### DIFF
--- a/BatteryPass/io.BatteryPass.CarbonFootprint/1.2.0/CarbonFootprintForBatteries.ttl
+++ b/BatteryPass/io.BatteryPass.CarbonFootprint/1.2.0/CarbonFootprintForBatteries.ttl
@@ -5,11 +5,11 @@
 # information regarding copyright ownership.
 #
 # This work is made available under the terms of the
-# Creative Commons Attribution 4.0 International (CC BY-NC 4.0) license,
+# Creative Commons Attribution 4.0 International (CC BY 4.0) license,
 # which is available at
-# https://creativecommons.org/licenses/by-nc/4.0/.
+# https://creativecommons.org/licenses/by/4.0/.
 #
-# SPDX-License-Identifier: CC-BY-NC-4.0
+# SPDX-License-Identifier: CC-BY-4.0
 #######################################################################
 
 @prefix samm: <urn:samm:org.eclipse.esmf.samm:meta-model:2.1.0#> .

--- a/BatteryPass/io.BatteryPass.GeneralProductInformation/1.2.0/GeneralProductInformation.ttl
+++ b/BatteryPass/io.BatteryPass.GeneralProductInformation/1.2.0/GeneralProductInformation.ttl
@@ -5,11 +5,11 @@
 # information regarding copyright ownership.
 #
 # This work is made available under the terms of the
-# Creative Commons Attribution 4.0 International (CC BY-NC 4.0) license,
+# Creative Commons Attribution 4.0 International (CC BY 4.0) license,
 # which is available at
-# https://creativecommons.org/licenses/by-nc/4.0/.
+# https://creativecommons.org/licenses/by/4.0/.
 #
-# SPDX-License-Identifier: CC-BY-NC-4.0
+# SPDX-License-Identifier: CC-BY-4.0
 #######################################################################
 
 #######################################################################

--- a/BatteryPass/io.BatteryPass.Labels/1.2.0/Labeling.ttl
+++ b/BatteryPass/io.BatteryPass.Labels/1.2.0/Labeling.ttl
@@ -5,11 +5,11 @@
 # information regarding copyright ownership.
 #
 # This work is made available under the terms of the
-# Creative Commons Attribution 4.0 International (CC BY-NC 4.0) license,
+# Creative Commons Attribution 4.0 International (CC BY 4.0) license,
 # which is available at
-# https://creativecommons.org/licenses/by-nc/4.0/.
+# https://creativecommons.org/licenses/by/4.0/.
 #
-# SPDX-License-Identifier: CC-BY-NC-4.0
+# SPDX-License-Identifier: CC-BY-4.0
 #######################################################################
 
 @prefix samm: <urn:samm:org.eclipse.esmf.samm:meta-model:2.1.0#> .

--- a/BatteryPass/io.BatteryPass.MaterialComposition/1.2.0/MaterialComposition.ttl
+++ b/BatteryPass/io.BatteryPass.MaterialComposition/1.2.0/MaterialComposition.ttl
@@ -5,11 +5,11 @@
 # information regarding copyright ownership.
 #
 # This work is made available under the terms of the
-# Creative Commons Attribution 4.0 International (CC BY-NC 4.0) license,
+# Creative Commons Attribution 4.0 International (CC BY 4.0) license,
 # which is available at
-# https://creativecommons.org/licenses/by-nc/4.0/.
+# https://creativecommons.org/licenses/by/4.0/.
 #
-# SPDX-License-Identifier: CC-BY-NC-4.0
+# SPDX-License-Identifier: CC-BY-4.0
 #######################################################################
 
 @prefix samm: <urn:samm:org.eclipse.esmf.samm:meta-model:2.1.0#> .

--- a/BatteryPass/io.BatteryPass.SupplyChainDueDiligence/1.2.0/SupplyChainDueDiligence.ttl
+++ b/BatteryPass/io.BatteryPass.SupplyChainDueDiligence/1.2.0/SupplyChainDueDiligence.ttl
@@ -5,11 +5,11 @@
 # information regarding copyright ownership.
 #
 # This work is made available under the terms of the
-# Creative Commons Attribution 4.0 International (CC BY-NC 4.0) license,
+# Creative Commons Attribution 4.0 International (CC BY 4.0) license,
 # which is available at
-# https://creativecommons.org/licenses/by-nc/4.0/.
+# https://creativecommons.org/licenses/by/4.0/.
 #
-# SPDX-License-Identifier: CC-BY-NC-4.0
+# SPDX-License-Identifier: CC-BY-4.0
 #######################################################################
 
 @prefix samm: <urn:samm:org.eclipse.esmf.samm:meta-model:2.1.0#> .

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,5 +1,7 @@
 # Changelog
 All notable changes to the battery passport data model will be documented in this file.
+## [1.2.0] - 2025-10-23
+ - Lincense consistently updated to Creative Commons Attribution 4.0 International (CC-BY-4.0) license. See the [LICENSE](https://creativecommons.org/licenses/by/4.0/legalcode) file for more details. 
 
 ## [1.2.0] - 2025-01-14
 ### Updated


### PR DESCRIPTION
Some licence information in the source files (*.ttl) unintentionally continued to show CC-BY-NC-4.0 (non-commercial). This update corrects this and sets all licence information in the source files (*.ttl) to the Creative Commons Attribution 4.0 International (CC-BY-4.0) licence to bring it into line with the licence information in README. Further details can be found in the file ‘https://creativecommons.org/licenses/by/4.0/legalcode’. This is intended to avoid confusion and reservations about the use of this data model or parts thereof in commercial solutions.

